### PR TITLE
* replaced Jim's   loadScript()

### DIFF
--- a/proxyjs/scoreboard/partialHTMLforSimpleScoring.html
+++ b/proxyjs/scoreboard/partialHTMLforSimpleScoring.html
@@ -5,104 +5,116 @@
 </div>
 
 <div id="sst-controls">
-  <table>
-    <tr>
-      <td>
-        <div class="sst-compare-button-group-div">
+    <table>
+        <tr>
+            <td>
+                <div class="sst-compare-button-group-div">
 
-          <fieldset>
-            <legend>Compare worksheet with:</legend>
-            <table class="sst-inside-fieldset">
-              <tr>
-                <td>
-                  <button id="sst-compare-excel" class="compare-group" type="button" onclick="sstCompareClicked()">Another Google<br/>sheet or .xlsx</button> 
-                </td>
-                <td>
-                  <button id="sst-compare-usac" class="compare-group"type="button" onclick="sstCompareUSACClicked()">USAC computed ranking</button> 
-                </td>
-              </tr>
-            </table>
+                    <fieldset>
+                        <legend>Compare worksheet with:</legend>
+                        <table class="sst-inside-fieldset">
+                            <tr>
+                                <td>
+                                    <button id="sst-compare-excel" class="compare-group" type="button" onclick="sstCompareClicked()">Another Google<br/>sheet or .xlsx</button>
+                                </td>
+                                <td>
+                                    <button id="sst-compare-usac" class="compare-group"type="button" onclick="sstCheckRankComputationClicked()">USAC computed ranking</button>
+                                </td>
+                            </tr>
+                        </table>
 
-          </fieldset>
+                    </fieldset>
+                </div>
+
+            </td>
+            <td>
+
+                <div class="sst-round-category-selection">
+                    <fieldset>
+                        <legend>Push scores from these categories to USAC</legend>
+                        <div id="sst-form">
+                            <table id="sst-table">
+                                <tr>
+                                    <td>
+                                        <div class="switch">
+                                            <input id="sst-toggle-1" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="FJR" checked>
+                                            <label for="sst-toggle-1" data-on="FJR ✓" data-off="fjr"></label>
+                                        </div>
+                                        <div class="switch">
+                                            <input id="sst-toggle-2" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="MJR">
+                                            <label for="sst-toggle-2" data-on="MJR ✓" data-off="mjr"></label>
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <div class="switch">
+                                            <input id="sst-toggle-3" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="FYA">
+                                            <label for="sst-toggle-3" data-on="FYA ✓" data-off="fya"></label>
+                                        </div>
+                                        <div class="switch">
+                                            <input id="sst-toggle-4" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="MYA">
+                                            <label for="sst-toggle-4" data-on="MYA ✓" data-off="mya"></label>
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <div class="switch">
+                                            <input id="sst-toggle-5" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="FYB">
+                                            <label for="sst-toggle-5" data-on="FYB ✓" data-off="fyb"></label>
+                                        </div>
+                                        <div class="switch">
+                                            <input id="sst-toggle-6" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="MYB">
+                                            <label for="sst-toggle-6" data-on="MYB ✓" data-off="myb"></label>
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <div class="switch">
+                                            <input id="sst-toggle-7" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="FYC">
+                                            <label for="sst-toggle-7" data-on="FYC ✓" data-off="fyc"></label>
+                                        </div>
+                                        <div class="switch">
+                                            <input id="sst-toggle-8" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="MYC">
+                                            <label for="sst-toggle-8" data-on="MYC ✓" data-off="myc"></label>
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <div class="switch">
+                                            <input id="sst-toggle-9" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="FYD">
+                                            <label for="sst-toggle-9" data-on="FYD ✓" data-off="fyd"></label>
+                                        </div>
+                                        <div class="switch">
+                                            <input id="sst-toggle-10" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="MYD">
+                                            <label for="sst-toggle-10" data-on="MYD ✓" data-off="myd"></label>
+                                        </div>
+                                    </td>
+                                    <td class="far-right-cell-buttons">
+                                        <button id="sst-push-to-usac" type="button" onclick="sstPushtoUSACClicked()">Push to<br/>USAC</button>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </fieldset>
+                </div>
+            </td>
+        </tr>
+    </table>
+
+    <div id="sst-awaiting-push-to-usac-results-div">
+        <p id="sst-awaiting-autoconvert" style="text-align: center; display: none;">
+            Awaiting last specified Excel workbook to be converted.
+        </p>
+        <p id="sst-awaiting-p" style="text-align: center; display: none;">
+            Awaiting data to be confirmed:
+            <span id="sst-awaiting-span"></span>
+        </p>
+    </div>
+
+    <div id="sst-compare-results-wrapper" style="display: none">
+        <div class="sst-close-button">
+            <a href="javascript:void(0);" onclick="$('#sst-compare-results-wrapper').hide();">Close</a>
         </div>
+        <h4>Here are the results of the comparison</h4>
+        <div id="sst-compare-results-div">
 
-      </td>
-      <td>
-        
-        <div class="sst-round-category-selection">
-          <fieldset>
-            <legend>Push scores from these categories to USAC</legend>
-            <div id="sst-form">
-              <table id="sst-table">
-                <tr>
-                  <td>
-                    <div class="switch">
-                      <input id="sst-toggle-1" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="FJR" checked>
-                      <label for="sst-toggle-1" data-on="FJR ✓" data-off="fjr"></label>
-                    </div>
-                    <div class="switch">
-                      <input id="sst-toggle-2" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="MJR">
-                      <label for="sst-toggle-2" data-on="MJR ✓" data-off="mjr"></label>
-                    </div>
-                  </td>
-                  <td>
-                    <div class="switch">
-                      <input id="sst-toggle-3" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="FYA">
-                      <label for="sst-toggle-3" data-on="FYA ✓" data-off="fya"></label>
-                    </div>
-                    <div class="switch">
-                      <input id="sst-toggle-4" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="MYA">
-                      <label for="sst-toggle-4" data-on="MYA ✓" data-off="mya"></label>
-                    </div>
-                  </td>
-                  <td>
-                    <div class="switch">
-                      <input id="sst-toggle-5" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="FYB">
-                      <label for="sst-toggle-5" data-on="FYB ✓" data-off="fyb"></label>
-                    </div>
-                    <div class="switch">
-                      <input id="sst-toggle-6" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="MYB">
-                      <label for="sst-toggle-6" data-on="MYB ✓" data-off="myb"></label>
-                    </div>
-                  </td>
-                  <td>
-                    <div class="switch">
-                      <input id="sst-toggle-7" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="FYC">
-                      <label for="sst-toggle-7" data-on="FYC ✓" data-off="fyc"></label>
-                    </div>
-                    <div class="switch">
-                      <input id="sst-toggle-8" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="MYC">
-                      <label for="sst-toggle-8" data-on="MYC ✓" data-off="myc"></label>
-                    </div>
-                  </td>
-                  <td>
-                    <div class="switch">
-                      <input id="sst-toggle-9" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="FYD">
-                      <label for="sst-toggle-9" data-on="FYD ✓" data-off="fyd"></label>
-                    </div>
-                    <div class="switch">
-                      <input id="sst-toggle-10" class="sst-toggle sst-toggle-yes-no" type="checkbox" value="MYD">
-                      <label for="sst-toggle-10" data-on="MYD ✓" data-off="myd"></label>
-                    </div>
-                  </td>
-                  <td class="far-right-cell-buttons">
-                    <button id="sst-push-to-usac" type="button" onclick="sstPushtoUSACClicked()">Push to<br/>USAC</button>
-                  </td>
-                  <td>
-                    <p id="sst-awaiting-autoconvert" style="text-align: center; display: none;">
-                      Awaiting last specified Excel workbook to be converted.
-                    </p>
-                    <p id="sst-awaiting-p" style="text-align: center; display: none;">
-                      Awaiting data to be confirmed:
-                      <span id="sst-awaiting-span"></span>
-                    </p>
-                  </td>
-                </tr>
-              </table>
-            </div>
-          </fieldset>
         </div>
-      </td>
-    </tr>
-  </table>
+    </div>
+
 </div>

--- a/proxyjs/scoreboard/partialHTMLforSimpleScoring.html
+++ b/proxyjs/scoreboard/partialHTMLforSimpleScoring.html
@@ -112,6 +112,10 @@
             <a href="javascript:void(0);" onclick="$('#sst-compare-results-wrapper').hide();">Close</a>
         </div>
         <h4>Here are the results of the comparison</h4>
+        <div id="sst-compare-auto-div">
+            <input type="checkbox" id="sst-compare-fix-usacpage-automatic-checkbox"/>
+            <label for="sst-compare-fix-usacpage-automatic-checkbox">Try to automatically set the round and display the round results for all categories</label>
+        </div>
         <div id="sst-compare-results-div">
 
         </div>

--- a/proxyjs/scoreboard/scoreboard.js
+++ b/proxyjs/scoreboard/scoreboard.js
@@ -69,7 +69,7 @@ function ScoringView(id) {
 	$('#pagetitle').show();
 	$('#divIntro').show();
 	$('div.footer-wrapper').show();
-	$(".sst-controls").hide();
+	$("#sst-controls").hide();
 	$(".sst-round-category-selection").hide();
 	$("#divSheets").hide();
 	break;
@@ -78,7 +78,7 @@ function ScoringView(id) {
 	$('#pagetitle').hide();
 	$('#divIntro').hide();
 	$('div.footer-wrapper').hide();
-	$(".sst-controls").show();
+	$("#sst-controls").show();
 	$(".sst-round-category-selection").show();
 	$("#divSheets").show();
 	break;
@@ -90,6 +90,7 @@ function loadStyle(cssfile)
 {
     $("head").append($('<style></style>').load(cssfile));
 }
+/* 
 
 function loadScript(jsfile)
 {
@@ -106,6 +107,26 @@ function loadScript(jsfile)
 		    }
 		});
 }
+*/  // replaced $.getScript with this bit by Alex Sorokoletov from http://stackoverflow.com/questions/690781/debugging-scripts-added-via-jquery-getscript-function
+var loadScript = function (path) {
+    var result = $.Deferred(),
+        script = document.createElement("script");
+    script.async = "async";
+    script.type = "text/javascript";
+    script.src = path;
+    script.onload = script.onreadystatechange = function (_, isAbort) {
+        if (!script.readyState || /loaded|complete/.test(script.readyState)) {
+            if (isAbort)
+                result.reject();
+            else
+                result.resolve();
+        }
+    };
+    script.onerror = function () { result.reject(); };
+    $("head")[0].appendChild(script);
+    return result.promise();
+};
+
 
 if (window.attachEvent) {
     window.attachEvent('onload', scoreboardInit);

--- a/proxyjs/scoreboard/senddata2usac.js
+++ b/proxyjs/scoreboard/senddata2usac.js
@@ -68,14 +68,14 @@ function sstonSaveScoresOnsightResponse(objXMLHTTP) {     // Does not update dat
             ipjUSACFlagForRefresh(true);    // TODO - maybe this should be for all responses?
             var tab = document.querySelector(".usac-view .event-view .tab-header[data-disciplineid='" + Math.abs(did) + "']");
             var tabBody = document.querySelector(".usac-view .event-view .tab-body[data-disciplineid='" + Math.abs(did) + "']");
-            alert("Scores could not be saved because the current round is no longer available for scoring. Click OK to refresh.");
+            alert("USAC did not acknowledge success. Try pushing scores again. ");
             tabBody.innerHTML = s.substring(s.indexOf("|") + 1);
             tab.setAttribute("data-loaded", "true");
             ipjUSACSetVisibleCategories(did);
         }
-        alert('An error occurred saving scores for onsight. Perhaps you did not complete a round to allow for entering scores of this selected round for the selected category.' + s);
+        alert('An error occurred saving scores for onsight. Perhaps you did not Complete Round (previous), to allow for entering scores of this selected round for the selected category.' + s);
     } catch (e) {
-        alert('An exception occurred saving scores for onsight.');
+        alert('An exception occurred saving scores for onsight. Try pushing scores again.');
     } finally {
         // TODO - ipjUSACBusy = false;
         if (r != "s3") {

--- a/proxyjs/scoreboard/senddata2usac.js
+++ b/proxyjs/scoreboard/senddata2usac.js
@@ -88,10 +88,10 @@ function sstonSaveScoresOnsightResponse(objXMLHTTP) {     // Does not update dat
 
 function sstChangeRound(catName, rid) {
     // Change Round
-    var t = $("<span></span>");
+    var s = $("<span></span>");
     var a = $("<a></a>");
-    t.append(a);
-    ipjUSACRoundClick(t[0], sstGetEventId(), sstGetDisciplineId, sstCategoryName2CatId[catName], sstCategoryName2Gender[catName], rid);
+    s.append(a);
+    ipjUSACRoundClick(a[0], sstGetEventId(), sstGetDisciplineId(), sstCategoryName2CatId[catName], sstCategoryName2Gender[catName], rid);
 }
 
 function sstShowRoundResults(catName, rid) {

--- a/proxyjs/scoreboard/senddata2usac.js
+++ b/proxyjs/scoreboard/senddata2usac.js
@@ -85,3 +85,19 @@ function sstonSaveScoresOnsightResponse(objXMLHTTP) {     // Does not update dat
 
     return false;
 }
+
+function sstChangeRound(catName, rid) {
+    // Change Round
+    var t = $("<span></span>");
+    var a = $("<a></a>");
+    t.append(a);
+    ipjUSACRoundClick(t[0], sstGetEventId(), sstGetDisciplineId, sstCategoryName2CatId[catName], sstCategoryName2Gender[catName], rid);
+}
+
+function sstShowRoundResults(catName, rid) {
+    var t = $("<input></input>");
+    var label = $("<label></label>");
+    var d = $("<div></div>").append(t).append(label);
+    
+    ipjUSACShowOnsightTotals(t[0], sstGetEventId(), sstGetDisciplineId(), sstCategoryName2CatId[catName], sstCategoryName2Gender[catName], rid);  // if returns false, then there was data that the user entered that should be saved first
+}

--- a/proxyjs/scoreboard/simplescoring.js
+++ b/proxyjs/scoreboard/simplescoring.js
@@ -444,8 +444,14 @@ function sstPrint(s, isGood, fixItFunction) {
             .text("Fix it!"));
     }
 
-    $("#sst-compare-results-div")
+    var resultsDiv = $("#sst-compare-results-div")
         .append(p);
+
+    var ps = $("#sst-compare-results-div").children('p');
+    ps.sort(function(a, b) {
+        return a.textContent.localeCompare(b.textContent);
+    });
+    ps.detach().appendTo(resultsDiv);
 }
 function sstPrintResetShow() {
     $("#sst-compare-results-div").empty();

--- a/proxyjs/scoreboard/simplescoring.js
+++ b/proxyjs/scoreboard/simplescoring.js
@@ -55,7 +55,10 @@ var sstRoundName2Rid = {   // TODO - these values were good in the TEST Regional
     Qualifiers: 1,
     Finals: 0,
     SuperFinals: -1,
-    SemiFinal:2            // TODO - Guessing
+    SemiFinal: 2,            // TODO - Guessing
+    Qualifier: 1,           // TODO - hack stupid 's' at the end
+    Final: 0,
+    SuperFinal: -1
 };
 var sstRid2RoundAbbrev = { // TODO - these values were good in the TEST Regional and Divisional
     "1": "Q",
@@ -428,17 +431,28 @@ function sstCompareCVM(categoryName, cvmMain, cvm2nd) {
     sstPrint(categoryName + " comparison complete.",true);
 }
 
-function sstPrint(s, isGood) {
+function sstPrint(s, isGood, fixItFunction) {
+    var p = $("<p></p>")
+        .addClass("sst-compare-result-p")
+        .addClass(isGood ? "sst-good" : "")
+        .text(s);
+
+    if (fixItFunction) {
+        p.append($("<a></a>")
+            .addClass("sst-compare-result-fixit")
+            .click(fixItFunction)
+            .text("Fix it!"));
+    }
+
     $("#sst-compare-results-div")
-        .append($("<p></p>")
-            .addClass("sst-compare-result-p")
-            .addClass(isGood ? "sst-good":"")
-            .text(s)
-        );
+        .append(p);
 }
 function sstPrintResetShow() {
     $("#sst-compare-results-div").empty();
     $("#sst-compare-results-wrapper").show();
+}
+function sstPrintHideFixIt(target) {
+    $(target).hide();
 }
 
 function sstGetJQArrayClimbers(cvm) {
@@ -478,11 +492,13 @@ function sstCheckRankComputationClicked() {
             sstCheckRankCompClosure(cvmOnWebPage)
             );
         } else {
-            sstPrint(cvmOnWebPage.Name + " are not currently showing round ranks.", true);
+            sstPrint(cvmOnWebPage.Name + " on the USAC page is not currently showing round results.", true, function(evt) { sstShowRoundResults(catName, sstRoundName2Rid[cvmOnWebPage.RoundName]);sstPrintHideFixIt(evt.target) });
         }
     });
     
 }
+
+
 function sstCheckRankCompClosure(cvmOnWebPage) {
     return function(sheetCVM) {
         sstCheckRankComp(sheetCVM, cvmOnWebPage);

--- a/proxyjs/scoreboard/simplescoring.js
+++ b/proxyjs/scoreboard/simplescoring.js
@@ -451,8 +451,9 @@ function sstPrintResetShow() {
     $("#sst-compare-results-div").empty();
     $("#sst-compare-results-wrapper").show();
 }
-function sstPrintHideFixIt(target) {
-    $(target).hide();
+function sstPrintFixItFinished(target) {
+    //$(target).hide();
+    $(target).text("Done.  Try compare again.");
 }
 
 function sstGetJQArrayClimbers(cvm) {
@@ -487,17 +488,10 @@ function sstCheckRankComputationClicked() {
         cvmOnWebPage.Name = catName;
         sstFindClimbers(cvmOnWebPage);
 
-        if (cvmOnWebPage.IsRankGathered) {
-            sstPullSheetData(sstActiveSheetId, catName,
-            sstCheckRankCompClosure(cvmOnWebPage)
-            );
-        } else {
-            sstPrint(cvmOnWebPage.Name + " on the USAC page is not currently showing round results.", true, function(evt) { sstShowRoundResults(catName, sstRoundName2Rid[cvmOnWebPage.RoundName]);sstPrintHideFixIt(evt.target) });
-        }
+        sstPullSheetData(sstActiveSheetId, catName, sstCheckRankCompClosure(cvmOnWebPage));
     });
     
 }
-
 
 function sstCheckRankCompClosure(cvmOnWebPage) {
     return function(sheetCVM) {
@@ -506,7 +500,13 @@ function sstCheckRankCompClosure(cvmOnWebPage) {
 }
 function sstCheckRankComp(sheetCVM, cvmOnWebPage) {
     if (sheetCVM.RoundName.substring(0, 4) != cvmOnWebPage.RoundName.substring(0, 4)) {
-        sstPrint(sheetCVM.Name + " is set to different rounds. [" + sheetCVM.RoundName + " vs. " + cvmOnWebPage.RoundName + "]");
+        sstPrint(sheetCVM.Name + " is set to different rounds. [" + sheetCVM.RoundName + " vs. " + cvmOnWebPage.RoundName + "]",
+            true,
+            function (evt) { sstChangeRound(sheetCVM.Name, sstRoundName2Rid[sheetCVM.RoundName]); sstPrintFixItFinished(evt.target) });
+        return;
+    }
+    if (!cvmOnWebPage.IsRankGathered) {
+        sstPrint(cvmOnWebPage.Name + " on the USAC page is not currently showing round results.", true, function (evt) { sstShowRoundResults(cvmOnWebPage.Name, sstRoundName2Rid[cvmOnWebPage.RoundName]); sstPrintFixItFinished(evt.target) });
         return;
     }
 

--- a/proxyjs/scoreboard/sst.css
+++ b/proxyjs/scoreboard/sst.css
@@ -27,6 +27,7 @@ table.sst-inside-fieldset {
     background-color: #d2292e;
     color: white;
     font-size: 14px;
+    cursor: pointer;
 }
 .sst-compare-button-group-div button.compare-group {
     padding: 4px;
@@ -112,6 +113,13 @@ td.far-right-cell-buttons {
 #sst-compare-results-wrapper  #sst-compare-results-div p.sst-compare-result-p.sst-good {
     background-color: inherit;
 }
+
+.sst-compare-result-fixit {
+    margin-left: 10px;
+    cursor: pointer;
+    color: red;
+}
+
 
 /* CSS for fancy checkboxes */
 


### PR DESCRIPTION
* Move in comparison results div, and move Push status message below buttons.
* Fixup mouse pointer for button, and actually prove by test hiding #sst-controls.
* implement fixit link for just moving to Round Results for a single category.  Not ideal design, but might be the first step to allowing reasonable control / performance/ stability on the USAC page....